### PR TITLE
fix(build): downgrade go and simplify build to avoid go install issues

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -1,16 +1,13 @@
 APPNAME = lambdapack-example
 
-export CGO_ENABLED=0
-export GOOS=linux
-export GOARCH=arm64
-
 .PHONY: default
 default: clean build archive package deploy
 
 .PHONY: build
 build:
 	@mkdir -p dist
-	@go build -ldflags "-s -w" -trimpath -o ./dist .
+	@CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
+		go build -ldflags "-s -w" -trimpath -o ./dist .
 
 .PHONY: clean
 clean:

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,5 +1,5 @@
 module github.com/wolfeidau/lambdapack/example
 
-go 1.21.0
+go 1.20
 
 require github.com/aws/aws-lambda-go v1.41.0


### PR DESCRIPTION
Issue seen in consuming projects was an automatic upgrade of project, turns out this happens on go get..

```
go get -u -v  github.com/wolfeidau/lambdapack
go: accepting indirect upgrade from go@1.20 to 1.21.0
go: upgraded go 1.20 => 1.21.0
go: added github.com/alecthomas/kong v0.8.0
go: added github.com/wolfeidau/lambdapack v1.0.0
```
